### PR TITLE
Add lifetimes to enable borrowing from memtable in scan iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,21 +140,18 @@ impl ToyKV {
     // /// Immediately terminate (for use during testing, "pretend to crash")
     // pub(crate) fn terminate(&mut self) {}
 
-    pub fn scan(&mut self) -> KVIterator {
-        let mut m = MergeIterator::new();
-        // TODO need to figure out all the lifetimes in the
-        // store, such that we can borrow memtable here ---
-        // the ToyKV would need a lifetime and everything would
-        // have to use that lifetime such that the compiler can
-        // check the ToyKV lives beyond everything!
-        m.add_iterator(self.memtable.clone().into_iter().map(
-            |(key, value)| -> Result<KVRecord, Error> {
-                Ok(KVRecord {
-                    key: key.clone(),     // or key.to_owned()
-                    value: value.clone(), // assuming KVValue implements Clone
-                })
-            },
-        ));
+    pub fn scan<'a>(&'a self) -> KVIterator<'a> {
+        let mut m = MergeIterator::<'a>::new();
+        m.add_iterator(
+            self.memtable
+                .iter()
+                .map(|(key, value)| -> Result<KVRecord, Error> {
+                    Ok(KVRecord {
+                        key: key.clone(),     // or key.to_owned()
+                        value: value.clone(), // assuming KVValue implements Clone
+                    })
+                }),
+        );
         // TODO we're also cloning file-handles here but that's
         // a bit better than the whole memtable!!
         for t in self.sstables.iters() {
@@ -169,11 +166,11 @@ pub struct KV {
     pub value: Vec<u8>,
 }
 
-pub struct KVIterator {
-    i: MergeIterator,
+pub struct KVIterator<'a> {
+    i: MergeIterator<'a>,
 }
 
-impl Iterator for KVIterator {
+impl<'a> Iterator for KVIterator<'a> {
     type Item = Result<KV, ToyKVError>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/sstable.rs
+++ b/src/sstable.rs
@@ -82,7 +82,7 @@ impl SSTables {
         self.sstables.get(k)
     }
 
-    pub(crate) fn iters(&mut self) -> Vec<SSTableFileReader> {
+    pub(crate) fn iters(&self) -> Vec<SSTableFileReader> {
         let mut vec = vec![];
         for t in &self.sstables.tables {
             vec.push(t.duplicate());


### PR DESCRIPTION
Problem: The scan() method was cloning the entire memtable to avoid
lifetime issues, which is inefficient for large datasets.

Solution: Added lifetime parameters throughout the iterator chain:

1. Updated types with lifetimes:
   - MergeIterator<'a>
   - KVIterator<'a>
   - TableIterator<'a> type alias
   - impl<'a> Iterator for MergeIterator<'a>

2. Modified scan method:
   - Changed from self.memtable.clone().into_iter() to self.memtable.iter()
   - Updated signature to pub fn scan(&self) -> KVIterator<'_>
   - Now borrows from memtable instead of cloning entire BTreeMap

3. Lifetime safety:
   - Rust's borrow checker ensures ToyKV instance lives longer than any iterators
   - Still clone individual key/value data when creating KVRecord
   - Maintained existing API while improving memory efficiency

Result: Scan operations now avoid expensive memtable cloning while
maintaining memory safety through Rust's lifetime system.
