### PR TITLE
feat: sstable bloom filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fastrange-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90a1392cd6ec5ebe42ccaf251f2b7ba6be654c377f05c913f3898bfb2172512"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,9 +53,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
@@ -92,6 +107,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "sbbf-rs"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5525db49c7719816ac719ea8ffd0d0b4586db1a3f5d3e7751593230dacc642fd"
+dependencies = [
+ "cpufeatures",
+ "fastrange-rs",
+]
+
+[[package]]
+name = "sbbf-rs-safe"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9902ffeb2cff3f8c072c60c7d526ac9560fc9a66fe1dfc3c240eba5e2151ba3c"
+dependencies = [
+ "sbbf-rs",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,8 +191,10 @@ name = "toykv"
 version = "0.1.0"
 dependencies = [
  "fastrand",
+ "sbbf-rs-safe",
  "serde",
  "serde_json",
+ "siphasher",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ tempfile = "3.10.0"
 
 [dependencies]
 fastrand = "2.3.0"
+sbbf-rs-safe = "0.3.2"
 serde = {version = "1.0.219", features = ["derive"]}
 serde_json = "1.0.140"
+siphasher = "1.0.1"
 
 

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -5,12 +5,12 @@ use toykv::{error::ToyKVError, ToyKVBuilder};
 fn main() -> Result<(), ToyKVError> {
     let tmp_dir = tempfile::tempdir().unwrap();
 
-    let writes = 25000u32;
+    let writes = 100000u32;
 
     let now = Instant::now();
     let mut db = ToyKVBuilder::new()
         .wal_sync(toykv::WALSync::Off)
-        .wal_write_threshold(10000)
+        .wal_write_threshold(1000)
         .open(tmp_dir.path())?;
     let elapsed_time = now.elapsed();
     println!(

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -101,7 +101,7 @@ impl WAL {
         let mut cnt = 0;
         let mut last_read_seq = 0;
         while bytes.stream_position()? < size {
-            dbg!(bytes.stream_position()?);
+            // dbg!(bytes.stream_position()?);
             let rec = WALRecord::read_one(&mut bytes)?;
             // dbg!(&rec);
             match rec {


### PR DESCRIPTION
Issue: https://github.com/mikerhodes/toykv/issues/8

This commit adds a bloom filter to each sstable file.

When writing the sstable using TableBuilder, we add the keys to the
bloomfilter as we go. When we finalise the file, we write the bloom
filter at the end of the file, after the block metadata index.

TableIterator is able to read the bloom filter, and has new methods
might_contain_key and might_contain_hashed_key. The methods can be
used to determine whether a file might contain a key, or definitely
does not (per bloom filter behaviour).

The bloom filter is consulted during get single k/v operations in the
database. Instead of checking every sstable on disk for the key, the
bloom filter is used to efficiently filter out sstable files that
don't contain the key while iterating the TableIterators.

Bloom filters have no effect on scans.

Tests are not added for checking that bloom filters are used. Instead,
dbg!() calls are added (and commented out) that allow for checking that
the tables resulted in fewer on disk tables being consulted during
gets. This could be fixed by adding metrics for table iterations and
using these to confirm whether tables were filtered out.
