### PR TITLE
Combine memtable+WAL into single struct

### DIFF
--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,0 +1,119 @@
+use crossbeam_skiplist::map::Entry;
+use crossbeam_skiplist::SkipMap;
+use std::sync::Arc;
+use std::{io::Error, ops::Bound};
+
+use ouroboros::self_referencing;
+
+use crate::error::ToyKVError;
+use crate::kvrecord::{KVRecord, KVValue};
+use crate::wal::{self, WAL};
+
+/// The memtable and WAL
+pub(crate) struct Memtable {
+    memtable: Arc<SkipMap<Vec<u8>, KVValue>>,
+    wal: WAL,
+}
+
+impl Memtable {
+    pub(crate) fn new(
+        d: &std::path::Path,
+        wal_sync: crate::WALSync,
+    ) -> Result<Self, ToyKVError> {
+        let mut wal = wal::new(d, wal_sync);
+        let memtable = Arc::new(wal.replay()?);
+        Ok(Self { memtable, wal })
+    }
+
+    pub(crate) fn write(
+        &mut self,
+        k: Vec<u8>,
+        v: KVValue,
+    ) -> Result<(), ToyKVError> {
+        self.wal.write(&k, (&v).into())?;
+        self.memtable.insert(k, v);
+        Ok(())
+    }
+
+    pub(crate) fn wal_writes(&self) -> u64 {
+        self.wal.wal_writes
+    }
+
+    pub(crate) fn clear(&mut self) -> Result<(), ToyKVError> {
+        self.wal.reset()?;
+        self.memtable.clear();
+        Ok(())
+    }
+
+    pub(crate) fn get(&self, k: &[u8]) -> Option<KVValue> {
+        let r = self.memtable.get(k);
+        match r {
+            Some(r) => Some(r.value().to_owned()),
+            None => None,
+        }
+    }
+
+    pub(crate) fn iter(&self) -> MemtableIterator {
+        self.range(Bound::Unbounded, Bound::Unbounded)
+    }
+
+    pub(crate) fn range(
+        &self,
+        lower_bound: Bound<Vec<u8>>,
+        end_key: Bound<Vec<u8>>,
+    ) -> MemtableIterator {
+        MemtableIteratorBuilder {
+            memtable: self.memtable.clone(),
+            it_builder: |mt| mt.range((lower_bound, end_key)),
+        }
+        .build()
+    }
+}
+
+// Make this a type because it's so long to write out
+type SkipMapRangeIter<'a> = crossbeam_skiplist::map::Range<
+    'a,
+    Vec<u8>,
+    (Bound<Vec<u8>>, Bound<Vec<u8>>),
+    Vec<u8>,
+    KVValue,
+>;
+
+// I realised quite quickly that I needed to somehow put the memtable Arc
+// clone into a struct alongside the iterator that borrowed it. But I
+// couldn't for the life of me construct something that the compiler
+// would accept; usually I could see why. It took me a while to figure
+// out that I needed a crate to help with it.
+#[self_referencing]
+pub(crate) struct MemtableIterator {
+    memtable: Arc<SkipMap<Vec<u8>, KVValue>>,
+    #[borrows(memtable)]
+    #[not_covariant]
+    it: SkipMapRangeIter<'this>,
+}
+
+impl MemtableIterator {
+    pub(crate) fn len(&self) -> usize {
+        self.borrow_memtable().len()
+    }
+
+    fn entry_to_kvrecord(
+        entry: Entry<Vec<u8>, KVValue>,
+    ) -> Result<KVRecord, Error> {
+        Ok(KVRecord {
+            key: entry.key().clone(),
+            value: entry.value().clone(),
+        })
+    }
+}
+
+impl Iterator for MemtableIterator {
+    type Item = Result<KVRecord, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.with_it_mut(|iter| match iter.next() {
+            None => None,
+            Some(entry) => Some(MemtableIterator::entry_to_kvrecord(entry)),
+        })
+    }
+}

--- a/src/table/builder.rs
+++ b/src/table/builder.rs
@@ -15,7 +15,7 @@ use siphasher::sip::SipHasher13;
 
 use crate::{
     block::{BlockBuilder, BlockBuilderError},
-    kvrecord::KVWriteValue,
+    kvrecord::KVValue,
 };
 
 use super::BlockMeta;
@@ -61,7 +61,7 @@ impl TableBuilder {
     pub(super) fn add(
         &mut self,
         key: &[u8],
-        value: &KVWriteValue,
+        value: &KVValue,
     ) -> Result<(), BlockBuilderError> {
         let mut r = self.bb.add(key, value);
 

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-    kvrecord::{KVRecord, KVValue, KVWriteRecord, KVWriteValue},
+    kvrecord::{KVRecord, KVValue, KVWriteRecord},
     ToyKVError, WALSync,
 };
 
@@ -137,7 +137,7 @@ impl WAL {
     pub(crate) fn write(
         &mut self,
         key: &[u8],
-        value: KVWriteValue,
+        value: &KVValue,
     ) -> Result<(), ToyKVError> {
         if self.f.is_none() {
             return Err(ToyKVError::BadWALState);
@@ -244,7 +244,7 @@ impl WALRecord {
         w: &mut T,
         seq: u32,
         key: &[u8],
-        value: KVWriteValue,
+        value: &KVValue,
     ) -> Result<(), Error> {
         // Create our record and attempt to write
         // it out in one go.


### PR DESCRIPTION
Move memtable+wal to module; remove KVWriteValue

Issue: https://github.com/mikerhodes/toykv/issues/16

Move memtable and WAL into a single struct, and move to the
src/memtable.rs module.

As part of this work, it was neccessary to change a couple of
KVWriteValue into KVValues. Originally, KVWriteValue was designed
so that we didn't have to clone the byte arrays for the values, it
just contained a slice unlike KVValue that has a Vec<u8>.

However, once I'd changed a couple of the KVWriteValue values to
KVValue, it became clearer that it was just as efficient to use
KVValues everywhere. The memtable takes a KVValue as its value, and
needs ownership. By passing the KVValue by reference into the WAL
write methods, it's just as efficient as the way KVWriteValue used
a slice inside the struct.

The change to KVValue changed a lot of tests that passed in slices,
but I think overall it makes the code better to remove a type that
had become unneeded.

Performance

cargo run --example bench
Running read() 100000 times took 8354ms (0.083ms per read).
cargo run --exampe bench_scan
Running scan() 998 times took 8681ms (8.699ms per scan).