### PR TITLE
frozen memtable reject writes

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -19,12 +19,17 @@ fn main() -> Result<(), ToyKVError> {
     );
 
     let now = Instant::now();
-    for n in 1..(writes + 1) {
+    let mut n = 1;
+    while n < writes + 1 {
         match db.set(n.to_be_bytes().to_vec(), n.to_le_bytes().to_vec()) {
-            Ok(it) => it,
+            Ok(_) => n = n + 1,
+            Err(ToyKVError::NeedFlush) => {
+                db.flush_oldest_memtable()?;
+            }
             Err(err) => return Err(err),
         };
     }
+    dbg!(n);
     let elapsed_time = now.elapsed();
     println!("Running write() took {}ms.", elapsed_time.as_millis());
     // assert_eq!(2, db.metrics.sst_flushes);
@@ -34,6 +39,9 @@ fn main() -> Result<(), ToyKVError> {
     let now = Instant::now();
     for n in 1..(writes + 1) {
         let got = db.get(n.to_be_bytes().as_slice())?;
+        if got == None {
+            dbg!(n);
+        }
         assert_eq!(
             got.unwrap(),
             n.to_le_bytes().as_slice(),

--- a/examples/bench_scan.rs
+++ b/examples/bench_scan.rs
@@ -19,9 +19,13 @@ fn main() -> Result<(), ToyKVError> {
     );
 
     let now = Instant::now();
-    for n in 1..(writes + 1) {
+    let mut n = 0;
+    while n < writes + 1 {
         match db.set(n.to_be_bytes().to_vec(), n.to_le_bytes().to_vec()) {
-            Ok(it) => it,
+            Ok(_) => n = n + 1,
+            Err(ToyKVError::NeedFlush) => {
+                db.flush_oldest_memtable()?;
+            }
             Err(err) => return Err(err),
         };
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ pub enum ToyKVError {
     KeyEmpty,
     ValueEmpty,
     DatabaseShutdown,
+    // memtables are full and a flush is needed
+    NeedFlush,
 }
 
 impl From<&std::io::Error> for ToyKVError {

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,5 +1,6 @@
 use crossbeam_skiplist::map::Entry;
 use crossbeam_skiplist::SkipMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::{io::Error, ops::Bound};
 
@@ -17,10 +18,10 @@ pub(crate) struct Memtable {
 
 impl Memtable {
     pub(crate) fn new(
-        d: &std::path::Path,
+        wal_path: PathBuf,
         wal_sync: crate::WALSync,
     ) -> Result<Self, ToyKVError> {
-        let mut wal = wal::new(d, wal_sync);
+        let mut wal = wal::new(wal_path, wal_sync);
         let memtable = Arc::new(wal.replay()?);
         Ok(Self { memtable, wal })
     }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -26,6 +26,16 @@ impl Memtable {
         Ok(Self { memtable, wal })
     }
 
+    // An opaque ID for the memtable
+    pub(crate) fn id(&self) -> String {
+        self.wal.wal_path().to_str().unwrap().to_string()
+    }
+
+    // Path to the WAL on disk
+    pub(crate) fn wal_path(&self) -> PathBuf {
+        self.wal.wal_path().clone()
+    }
+
     pub(crate) fn write(
         &mut self,
         k: Vec<u8>,

--- a/src/memtables.rs
+++ b/src/memtables.rs
@@ -1,0 +1,153 @@
+use std::{
+    io::Error,
+    iter::repeat_with,
+    mem,
+    path::{Path, PathBuf},
+};
+
+use memtable::Memtable;
+use walindex::WALIndex;
+
+use crate::{
+    error::ToyKVError, kvrecord::KVValue, memtable, walindex, WALSync,
+};
+
+pub(crate) struct Memtables {
+    d: PathBuf,
+    wal_index: WALIndex,
+
+    /// active_memtable stores new writes before they
+    /// are moved to sstables. They have a WAL for
+    /// durability.
+    active_memtable: Memtable,
+    /// frozen_memtable exists to be written to disk
+    /// in the background, such that we can still
+    /// accept writes to the active memtable.
+    frozen_memtable: Option<Memtable>,
+    wal_write_threshold: u64,
+    wal_sync: WALSync,
+}
+
+impl Memtables {
+    pub(crate) fn new(
+        d: PathBuf,
+        wal_sync: WALSync,
+        wal_write_threshold: u64,
+    ) -> Result<Self, ToyKVError> {
+        let wal_index_path = d.join("wal_index.json");
+        let mut wal_index = WALIndex::open(wal_index_path)?;
+
+        // If there is a WAL on disk, load the active memtable
+        // from it, otherwise initialise a memtable with a fresh
+        // WAL file on disk.
+        let active_wal_path = match wal_index.active_wal() {
+            None => new_wal_path(&d),
+            Some(x) => x,
+        };
+        wal_index.set_active_wal(&active_wal_path)?;
+        let active_memtable = Memtable::new(active_wal_path, wal_sync)?;
+
+        // Unlike active memtable, we don't need to have a frozen
+        // memtable unless we exited running before we managed
+        // to save the frozen memtable to disk. Mostly the
+        // frozen memtable is transient, as it's saved to disk
+        // almost immediately.
+        let frozen_memtable = match wal_index.frozen_wal() {
+            None => None,
+            Some(x) => Some(Memtable::new(x, wal_sync)?),
+        };
+
+        Ok(Memtables {
+            d,
+            wal_index,
+            active_memtable,
+            frozen_memtable,
+            wal_write_threshold,
+            wal_sync,
+        })
+    }
+    pub(crate) fn write(
+        &mut self,
+        k: Vec<u8>,
+        v: KVValue,
+    ) -> Result<(), ToyKVError> {
+        if self.active_memtable.wal_writes() >= self.wal_write_threshold {
+            let new_wal_path = new_wal_path(&self.d);
+            let old_wal_path = self.wal_index.active_wal().unwrap();
+
+            self.wal_index.set_active_wal(&new_wal_path)?;
+            self.wal_index.set_frozen_wal(&old_wal_path)?;
+
+            let new_active_memtable =
+                Memtable::new(new_wal_path, self.wal_sync)?;
+
+            self.frozen_memtable = Some(mem::replace(
+                &mut self.active_memtable,
+                new_active_memtable,
+            ));
+        }
+        self.active_memtable.write(k, v)?;
+        Ok(())
+    }
+
+    /// Return true if there is no longer space writes in memtables
+    pub(crate) fn needs_flush(&self) -> bool {
+        // No space in active memtable and we have a frozen on already.
+        if self.active_memtable.wal_writes() >= self.wal_write_threshold {
+            self.frozen_memtable.is_some()
+        } else {
+            false
+        }
+    }
+
+    /// Return true if there is a non-active memtable available to flush.
+    pub(crate) fn can_flush(&self) -> bool {
+        return self.frozen_memtable.is_some();
+    }
+
+    pub(crate) fn write_frozen_memtable(
+        &self,
+        w: crate::table::SSTableWriter,
+    ) -> Result<crate::table::SSTableWriterResult, Error> {
+        assert!(self.frozen_memtable.is_some(), "frozen_memtable is None");
+        w.write(self.frozen_memtable.as_ref().unwrap().iter())
+    }
+
+    pub(crate) fn drop_frozen_memtable(&mut self) -> Result<(), ToyKVError> {
+        self.wal_index.remove_frozen_wal()?;
+        let ft = mem::replace(&mut self.frozen_memtable, None);
+        match ft {
+            Some(mut ft) => ft.cleanup_disk(),
+            None => Ok(()),
+        }
+    }
+
+    pub(crate) fn get(&self, k: &[u8]) -> Option<KVValue> {
+        match self.active_memtable.get(k) {
+            Some(r) => Some(r),
+            None => match &self.frozen_memtable {
+                None => None,
+                Some(t) => t.get(k),
+            },
+        }
+    }
+
+    pub(crate) fn iters(
+        &self,
+        lower_bound: std::ops::Bound<Vec<u8>>,
+        upper_bound: std::ops::Bound<Vec<u8>>,
+    ) -> Vec<memtable::MemtableIterator> {
+        let mut iters = vec![self
+            .active_memtable
+            .range(lower_bound.clone(), upper_bound.clone())];
+        if let Some(ft) = &self.frozen_memtable {
+            iters.push(ft.range(lower_bound, upper_bound))
+        }
+        iters
+    }
+}
+
+fn new_wal_path(dir: &Path) -> PathBuf {
+    let s: String = repeat_with(fastrand::alphanumeric).take(16).collect();
+    dir.join(format!("{}.wal", s))
+}

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -161,6 +161,10 @@ impl WAL {
         Ok(())
     }
 
+    pub(crate) fn wal_path(&self) -> PathBuf {
+        self.wal_path.clone()
+    }
+
     /// Delete the WAL file from disk.
     /// Take care; this could result in data loss if the
     /// associated memtable is not written to an sstable.

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -4,7 +4,7 @@ use crossbeam_skiplist::SkipMap;
 use std::{
     fs::{self, File, OpenOptions},
     io::{BufReader, Error, Read, Seek, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use crate::{
@@ -49,9 +49,9 @@ pub(crate) struct WAL {
     pub(crate) wal_writes: u64,
 }
 
-pub(crate) fn new(d: &Path, sync: WALSync) -> WAL {
+pub(crate) fn new(wal_path: PathBuf, sync: WALSync) -> WAL {
     WAL {
-        wal_path: d.join("db.wal"),
+        wal_path,
         f: None,
         sync,
         nextseq: 0,

--- a/src/walindex.rs
+++ b/src/walindex.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::{self},
+    io::{Error, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct WALIndexFile {
+    pub(crate) active_wal: Option<PathBuf>,
+}
+
+pub(crate) struct WALIndex {
+    wal_index_file: WALIndexFile,
+    backing_file_path: PathBuf,
+}
+
+impl WALIndex {
+    /// Read an index from disk, if it exists. Otherwise,
+    /// create and return a new index file.
+    pub(crate) fn open(p: PathBuf) -> Result<WALIndex, Error> {
+        match fs::read_to_string(&p) {
+            Ok(data) => {
+                let wif: WALIndexFile = serde_json::from_str(&data)?;
+                Ok(WALIndex {
+                    wal_index_file: wif,
+                    backing_file_path: p,
+                })
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                let wif = WALIndexFile { active_wal: None };
+                Ok(WALIndex {
+                    wal_index_file: wif,
+                    backing_file_path: p,
+                })
+            }
+            Err(x) => Err(x),
+        }
+    }
+
+    /// Set active WAL and write the index file
+    pub(crate) fn set_active_wal(&mut self, p: &Path) -> Result<(), Error> {
+        self.wal_index_file.active_wal = Some(p.to_path_buf());
+        fs::write(
+            &self.backing_file_path,
+            serde_json::to_string(&self.wal_index_file)?,
+        )
+    }
+
+    pub(crate) fn active_wal(&self) -> Option<PathBuf> {
+        match &self.wal_index_file.active_wal {
+            None => None,
+            Some(x) => Some(x.clone()),
+        }
+    }
+}

--- a/src/walindex.rs
+++ b/src/walindex.rs
@@ -57,7 +57,7 @@ impl WALIndex {
             Some(x) => Some(x.clone()),
         }
     }
-    /// Set active WAL and write the index file
+
     pub(crate) fn set_frozen_wal(&mut self, p: &Path) -> Result<(), Error> {
         self.wal_index_file.frozen_wal = Some(p.to_path_buf());
         fs::write(
@@ -71,5 +71,14 @@ impl WALIndex {
             None => None,
             Some(x) => Some(x.clone()),
         }
+    }
+
+    /// Remove the frozen WAL from the index
+    pub(crate) fn remove_frozen_wal(&mut self) -> Result<(), Error> {
+        self.wal_index_file.frozen_wal = None;
+        fs::write(
+            &self.backing_file_path,
+            serde_json::to_string(&self.wal_index_file)?,
+        )
     }
 }


### PR DESCRIPTION
Add a basic capability to use frozen memtables to allow write
spikes. Writes can temporarily build up by moving the active
memtable to a frozen memtable and continuing to accept writes.
However, when the active memtable fills up again, the frozen
memtable will need to be written to disk before more writes can
be accepted.

The flush must be done by the client, we don't automate that
for now. The client could do this when the write method fails
with a NeedFlush error (as we do in the examples/ directory)
or on a separate thread periodically. Right now, for simplicity,
writes are still blocked while the table is written out, so the
separate thread doesn't add much.

In addition, the PR adds the capability to use more than one
frozen memtable as the in memory buffer. It doesn't expose this
to the client, however, instead hard-coding a maximum of one
frozen memtable.

- **Remove hardcoded WAL filename by adding WAL index file**
- **Add frozen memtable to toykv and WALIndex**
- **Implement frozen memtable, fail writes if need flush**
- **Implement backend for multiple frozen memtables**
